### PR TITLE
Switch m68k to new GCC and binutils, fix CPUFLAGS.

### DIFF
--- a/external/gpl3/binutils.old/usr.bin/gas/arch/m68k/config.h
+++ b/external/gpl3/binutils.old/usr.bin/gas/arch/m68k/config.h
@@ -298,7 +298,7 @@
 #define TARGET_ALIAS "m68k--netbsdelf"
 
 /* Define as 1 if big endian. */
-/* #undef TARGET_BYTES_BIG_ENDIAN */
+#define TARGET_BYTES_BIG_ENDIAN 1
 
 /* Canonical target. */
 #define TARGET_CANONICAL "m68k--netbsdelf"

--- a/external/gpl3/binutils/usr.bin/gas/arch/m68k/config.h
+++ b/external/gpl3/binutils/usr.bin/gas/arch/m68k/config.h
@@ -317,7 +317,7 @@
 #define TARGET_ALIAS "m68k--netbsdelf"
 
 /* Define as 1 if big endian. */
-/* #undef TARGET_BYTES_BIG_ENDIAN */
+#define TARGET_BYTES_BIG_ENDIAN 1
 
 /* Canonical target. */
 #define TARGET_CANONICAL "m68k--netbsdelf"

--- a/external/gpl3/gcc.old/dist/libgcc/config/m68k/lb1sf68.S
+++ b/external/gpl3/gcc.old/dist/libgcc/config/m68k/lb1sf68.S
@@ -172,7 +172,7 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 	/* ISA C has no bra.l instruction, and since this assembly file
 	   gets assembled into multiple object files, we avoid the
 	   bra instruction entirely.  */
-#if defined (__mcoldfire__) && !defined (__mcfisab__)
+#if defined (__ELF__) || (defined (__mcoldfire__) && !defined (__mcfisab__))
 	lea	\addr-.-8,a0
 	jmp	pc@(a0)
 #else
@@ -211,7 +211,7 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 	/* ISA C has no bra.l instruction, and since this assembly file
 	   gets assembled into multiple object files, we avoid the
 	   bra instruction entirely.  */
-#if defined (__mcoldfire__) && !defined (__mcfisab__)
+#if defined (__ELF__) || (defined (__mcoldfire__) && !defined (__mcfisab__))
 	lea	\addr-.-8,a0
 	jmp	pc@(a0)
 #else

--- a/external/gpl3/gcc/dist/libgcc/config/m68k/lb1sf68.S
+++ b/external/gpl3/gcc/dist/libgcc/config/m68k/lb1sf68.S
@@ -172,7 +172,7 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 	/* ISA C has no bra.l instruction, and since this assembly file
 	   gets assembled into multiple object files, we avoid the
 	   bra instruction entirely.  */
-#if defined (__mcoldfire__) && !defined (__mcfisab__)
+#if defined (__ELF__) || (defined (__mcoldfire__) && !defined (__mcfisab__))
 	lea	\addr-.-8,a0
 	jmp	pc@(a0)
 #else
@@ -211,7 +211,7 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 	/* ISA C has no bra.l instruction, and since this assembly file
 	   gets assembled into multiple object files, we avoid the
 	   bra instruction entirely.  */
-#if defined (__mcoldfire__) && !defined (__mcfisab__)
+#if defined (__ELF__) || (defined (__mcoldfire__) && !defined (__mcfisab__))
 	lea	\addr-.-8,a0
 	jmp	pc@(a0)
 #else

--- a/share/mk/bsd.own.mk
+++ b/share/mk/bsd.own.mk
@@ -63,9 +63,6 @@ TOOLCHAIN_MISSING?=	no
 #
 # What GCC is used?
 #
-.if ${MACHINE_CPU} == "m68k"
-HAVE_GCC?=	7
-.endif
 HAVE_GCC?=	8
 
 #
@@ -163,7 +160,7 @@ EXTERNAL_GDB_SUBDIR=		/does/not/exist
     ${MACHINE_ARCH} == "powerpc64" || ${MACHINE_ARCH} == "powerpc" || \
     ${MACHINE_CPU} == "aarch64" || ${MACHINE_CPU} == "arm" || \
     ${MACHINE_ARCH} == "hppa" || ${MACHINE_ARCH} == "sparc64" || \
-    ${MACHINE} == "sun2" || ${MACHINE} == "alpha"
+    ${MACHINE_CPU} == "m68k" || ${MACHINE} == "alpha"
 HAVE_BINUTILS?=	234
 .else
 HAVE_BINUTILS?=	231

--- a/share/mk/bsd.sys.mk
+++ b/share/mk/bsd.sys.mk
@@ -234,7 +234,11 @@ CPUFLAGS+=	-Wa,--fatal-warnings
 #CPUFLAGS+=	-mno-abicalls -fno-PIC
 #.endif
 CFLAGS+=	${CPUFLAGS}
+
+# GNU assembler doesn't like some m68k flags, esp. for kernel locore.s, etc.
+.if ${MACHINE_CPU} != "m68k"
 AFLAGS+=	${CPUFLAGS}
+.endif
 
 .if ${KCOV:U0} > 0
 KCOVFLAGS=	-fsanitize-coverage=trace-pc,trace-cmp


### PR DESCRIPTION
- Change m68k build to use GCC 8.4.0 and binutils 2.34.
- Update binutils config files to define TARGET_BYTES_BIG_ENDIAN.
- Fix libgcc/config/m68k/lb1sf68.S to work around linker error
  when using CPUFLAGS (normally masked by default CPU options).
- Don't add CPUFLAGS to AFLAGS, to fix several build failures:
  - Amiga kernel locore.s uses opcodes not present in 68040/060
  - Amiga bootblocks use custom make rule that calls gas directly,
    and gas doesn't understand all m68k CPUFLAGS recognized by GCC.
  - m68060 kernel support package also doesn't like CPUFLAGS.