### PR TITLE
Insert missing whitespace for assembler flag rules.

### DIFF
--- a/external/gpl3/gcc/dist/gcc/config/m68k/m68k.h
+++ b/external/gpl3/gcc/dist/gcc/config/m68k/m68k.h
@@ -36,9 +36,9 @@ along with GCC; see the file COPYING3.  If not see
    and .arch directives.  */
 
 #define ASM_CPU_SPEC "\
-%{m68851}%{mno-68851} %{m68881}%{mno-68881} %{msoft-float:-mno-float} \
-%{m68020-40:-m68040}%{m68020-60:-m68040}\
-%{mcpu=*:-mcpu=%*}%{march=*:-march=%*}\
+ %{m68851} %{mno-68851} %{m68881} %{mno-68881} %{msoft-float:-mno-float}\
+ %{m68020-40:-m68040} %{m68020-60:-m68040}\
+ %{mcpu=*:-mcpu=%*} %{march=*:-march=%*}\
 "
 #define ASM_PCREL_SPEC "%{" FPIE_OR_FPIC_SPEC ":--pcrel} \
  %{mpcrel:%{" NO_FPIE_AND_FPIC_SPEC ":--pcrel}} \


### PR DESCRIPTION
Fixes assembler errors like "unrecognized option -m68040-mcpu=68040".